### PR TITLE
Changed Initial Value of `NexusForm.tx` Input Tags to `''`

### DIFF
--- a/src/client/components/NexusForm.tsx
+++ b/src/client/components/NexusForm.tsx
@@ -18,8 +18,10 @@ const Nexus = () => {
             parseFloat(el[1]),
         ]);
 
+        // Find center point between three coordinates
         const nexus = center(points(coordinatesAsPositions));
 
+        // Call OpenCage API to reverse geocode the nexus of coordinates to get address string
         try {
             const response = await opencage.geocode({
                 key: import.meta.env.VITE_OPENCAGE_API_KEY,

--- a/src/client/components/NexusForm.tsx
+++ b/src/client/components/NexusForm.tsx
@@ -6,14 +6,20 @@ import { useState } from 'react';
 const Nexus = () => {
     const [nexusAddress, setNexusAddress] = useState<null | string>(null);
     // TODO: Change from 0s to empty strings for better user experience inputting negative numbers from initial state
-    const [coordinates, setCoordinates] = useState<Position[]>([
-        [0, 0],
-        [0, 0],
-        [0, 0],
+    const [coordinates, setCoordinates] = useState<string[][]>([
+        ['', ''],
+        ['', ''],
+        ['', ''],
     ]);
 
     const handleSubmit = async () => {
-        const nexus = center(points(coordinates));
+        const coordinatesAsPositions: Position[] = coordinates.map((el) => [
+            parseFloat(el[0]),
+            parseFloat(el[1]),
+        ]);
+
+        const nexus = center(points(coordinatesAsPositions));
+
         try {
             const response = await opencage.geocode({
                 key: import.meta.env.VITE_OPENCAGE_API_KEY,
@@ -65,8 +71,8 @@ const Nexus = () => {
                         value={coordinates[0][1] ?? 0}
                         onChange={(e) => {
                             e.preventDefault();
-                            const newCoordinates: Position[] = [...coordinates];
-                            newCoordinates[0][1] = +e.target.value;
+                            const newCoordinates: string[][] = [...coordinates];
+                            newCoordinates[0][1] = e.target.value;
                             setCoordinates(newCoordinates);
                         }}
                     />
@@ -82,8 +88,8 @@ const Nexus = () => {
                         value={coordinates[0][0] ?? 0}
                         onChange={(e) => {
                             e.preventDefault();
-                            const newCoordinates: Position[] = [...coordinates];
-                            newCoordinates[0][0] = +e.target.value;
+                            const newCoordinates: string[][] = [...coordinates];
+                            newCoordinates[0][0] = e.target.value;
                             setCoordinates(newCoordinates);
                         }}
                     />
@@ -102,8 +108,8 @@ const Nexus = () => {
                         value={coordinates[1][1] ?? 0}
                         onChange={(e) => {
                             e.preventDefault();
-                            const newCoordinates: Position[] = [...coordinates];
-                            newCoordinates[1][1] = +e.target.value;
+                            const newCoordinates: string[][] = [...coordinates];
+                            newCoordinates[1][1] = e.target.value;
                             setCoordinates(newCoordinates);
                         }}
                     />
@@ -119,8 +125,8 @@ const Nexus = () => {
                         value={coordinates[1][0] ?? 0}
                         onChange={(e) => {
                             e.preventDefault();
-                            const newCoordinates: Position[] = [...coordinates];
-                            newCoordinates[1][0] = +e.target.value;
+                            const newCoordinates: string[][] = [...coordinates];
+                            newCoordinates[1][0] = e.target.value;
                             setCoordinates(newCoordinates);
                         }}
                     />
@@ -139,8 +145,8 @@ const Nexus = () => {
                         value={coordinates[2][1] ?? 0}
                         onChange={(e) => {
                             e.preventDefault();
-                            const newCoordinates: Position[] = [...coordinates];
-                            newCoordinates[2][1] = +e.target.value;
+                            const newCoordinates: string[][] = [...coordinates];
+                            newCoordinates[2][1] = e.target.value;
                             setCoordinates(newCoordinates);
                         }}
                     />
@@ -156,8 +162,8 @@ const Nexus = () => {
                         value={coordinates[2][0] ?? 0}
                         onChange={(e) => {
                             e.preventDefault();
-                            const newCoordinates: Position[] = [...coordinates];
-                            newCoordinates[2][0] = +e.target.value;
+                            const newCoordinates: string[][] = [...coordinates];
+                            newCoordinates[2][0] = e.target.value;
                             setCoordinates(newCoordinates);
                         }}
                     />

--- a/src/client/components/NexusForm.tsx
+++ b/src/client/components/NexusForm.tsx
@@ -5,7 +5,6 @@ import { useState } from 'react';
 
 const Nexus = () => {
     const [nexusAddress, setNexusAddress] = useState<null | string>(null);
-    // TODO: Change from 0s to empty strings for better user experience inputting negative numbers from initial state
     const [coordinates, setCoordinates] = useState<string[][]>([
         ['', ''],
         ['', ''],

--- a/src/client/components/NexusForm.tsx
+++ b/src/client/components/NexusForm.tsx
@@ -12,6 +12,7 @@ const Nexus = () => {
     ]);
 
     const handleSubmit = async () => {
+        // Convert strings from number input tags to numbers for turf.js points function
         const coordinatesAsPositions: Position[] = coordinates.map((el) => [
             parseFloat(el[0]),
             parseFloat(el[1]),


### PR DESCRIPTION
Closes #3 

This works better than having the default value be `0` because it allows user to type negative or positive integers from the the initial state of the tags' values instead having a weird leading zero that is hard to get rid of.

Here is the new, desired behavior: 


https://github.com/user-attachments/assets/191bb89c-fbf2-4368-996e-dceade14b246

